### PR TITLE
Add test to avoid max recursion errors

### DIFF
--- a/src/sage/graphs/graph.py
+++ b/src/sage/graphs/graph.py
@@ -7774,6 +7774,12 @@ class Graph(GenericGraph):
 
             sage: graphs.EmptyGraph().gomory_hu_tree()
             Graph on 0 vertices
+
+            sage: recursion_limit = sys.getrecursionlimit()
+            sage: G = graphs.PathGraph(Integer(recursion_limit))
+            sage: T = G.gomory_hu_tree(algorithm="FF")
+            sage: T.order() == recursion_limit
+            True
         """
         self._scream_if_not_simple()
 


### PR DESCRIPTION
This PR adds one test to the new non recursive version of the Gomory Hu processing. A test was missing to show that no recursion error occurs.
The test gets the current max recursion depth of the system, creates a graph with a unique Gomory Hu tree (path here) and computes it.
The new version of Gomory Hu is added with https://github.com/sagemath/sage/pull/38791


### :memo: Checklist



- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

https://github.com/sagemath/sage/pull/38791


